### PR TITLE
raster package needed a version number

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -56,7 +56,7 @@ info:
       version: 0.9-2
     raster:
       repo: CRAN
-      version:
+      version: 2.5-8
 contributors:
   - 
     name: Dave Blodgett


### PR DESCRIPTION
in classic Lindsay fashion, I forgot something and just really wanted to merge...to be fair, running `make` doesn't catch this error.