### PR TITLE
Map precip figs

### DIFF
--- a/scripts/fetch/fetch.geom_shp.R
+++ b/scripts/fetch/fetch.geom_shp.R
@@ -1,17 +1,20 @@
 fetch.geom_shp <- function(viz){
   
+  shp_crs <- viz[["shp_crs"]]
+  
   deps <- readDepends(viz)
-  crs <- deps[["crs"]][["crs_str"]]
+  transform_crs <- deps[["transform_crs"]][["crs_str"]]
   
   # read in the shapefile
   sp_poly <- rgdal::readOGR(dsn = viz[["filepath"]])
+  sp_poly@proj4string <- sp::CRS(shp_crs)
   
   # merge multiple polygons into one large polygon
   sp_poly@data <- dplyr::mutate(sp_poly@data, polygon = viz[["id"]])
   sp_poly_dissolve <- maptools::unionSpatialPolygons(sp_poly, IDs = sp_poly@data$polygon)
   
   # reproject the sp object
-  sp_poly_transf <- sp::spTransform(sp_poly_dissolve, CRSobj = crs)
+  sp_poly_transf <- sp::spTransform(sp_poly_dissolve, CRSobj = transform_crs)
   
   saveRDS(sp_poly_transf, viz[['location']])
 }

--- a/scripts/fetch/fetch.geom_shp.R
+++ b/scripts/fetch/fetch.geom_shp.R
@@ -7,7 +7,7 @@ fetch.geom_shp <- function(viz){
   sp_poly <- rgdal::readOGR(dsn = viz[["filepath"]])
   
   # merge multiple polygons into one large polygon
-  sp_poly@data <- dplyr::mutate(sp_poly@data, polygon = "one_polygon")
+  sp_poly@data <- dplyr::mutate(sp_poly@data, polygon = viz[["id"]])
   sp_poly_dissolve <- maptools::unionSpatialPolygons(sp_poly, IDs = sp_poly@data$polygon)
   
   # reproject the sp object

--- a/scripts/fetch/fetch.geom_transpose.R
+++ b/scripts/fetch/fetch.geom_transpose.R
@@ -4,6 +4,12 @@ fetch.geom_transpose <- function(viz){
   sp_poly_transpose <- maptools::elide(deps[["geom_sp"]], shift = c(0, viz[["vertical_trans_va"]]))
   sp::proj4string(sp_poly_transpose) <- sp::proj4string(deps[["geom_sp"]])
   
+  # create unique ids for the new transposed polygons
+  # there should only be one polygon at this point:
+  stopifnot(length(sp_poly_transpose@plotOrder) == 1)
+  new_id <- paste0(slot(sp_poly_transpose@polygons[[1]], name = "ID"), "_transposed")
+  slot(sp_poly_transpose@polygons[[1]], name = "ID") <- new_id
+  
   saveRDS(sp_poly_transpose, viz[['location']])
 }
 

--- a/scripts/process/process.precip_timestep.R
+++ b/scripts/process/process.precip_timestep.R
@@ -3,8 +3,9 @@ process.precip_timestep <- function(viz){
   deps <- readDepends(viz)
   precip_data <- deps[['precip_data']]
   timestep <- deps[["timestep"]][["date"]]
+  timezone <- deps[["timestep"]][["tz"]]
   
-  precip_data_ts <- dplyr::filter(precip_data, DateTime == timestep)
+  precip_data_ts <- dplyr::filter(precip_data, DateTime == as.POSIXct(timestep, tz=timezone))
   
   saveRDS(precip_data_ts, viz[['location']])
 }

--- a/scripts/visualize/visualize.map_precip.R
+++ b/scripts/visualize/visualize.map_precip.R
@@ -1,9 +1,15 @@
 visualize.map_precip <- function(viz){
   
   deps <- readDepends(viz)
+  precip_colors <- deps[["precip_colors"]]
+  precip_breaks <- deps[["precip_breaks"]]
   precip_data <- deps[["precip_data"]]
   geom_sp <- deps[["geom_sp"]]
   geom_sp_orig <- deps[["geom_sp_orig"]]
+  
+  precip_col <- precip_colors[cut(precip_data[["precipVal"]], 
+                                  breaks = precip_breaks, 
+                                  labels = FALSE)]
   
   png(viz[['location']])
   
@@ -15,6 +21,7 @@ visualize.map_precip <- function(viz){
   }
   
   sp::plot(geom_sp, col="darkgrey", add=add_to_map)
+  sp::plot(geom_sp, col = precip_col, border = NA, add=add_to_map)
   
   dev.off()
   

--- a/scripts/visualize/visualize.map_precip.R
+++ b/scripts/visualize/visualize.map_precip.R
@@ -14,14 +14,25 @@ visualize.map_precip <- function(viz){
   png(viz[['location']])
   
   if(!is.null(geom_sp_orig)){
-    sp::plot(geom_sp_orig, col="lightgrey")
+    
+    # calculate the center of both polygons (combine them first)
+    # so that appropriate limits can be used for the plot
+    geom_sp_combined <- maptools::spRbind(geom_sp, geom_sp_orig)
+    geom_sp_bbox <- sp::bbox(geom_sp_combined)
+    
+    sp::plot(geom_sp_orig, col="lightgrey", border = NA, 
+             xlim = geom_sp_bbox["x",], ylim = geom_sp_bbox["y",])
+    
     add_to_map <- TRUE
   } else {
     add_to_map <- FALSE
   }
   
-  sp::plot(geom_sp, col="darkgrey", add=add_to_map)
+
   sp::plot(geom_sp, col = precip_col, border = NA, add=add_to_map)
+  legend("bottom", legend = paste("<", round(precip_breaks[-1], 2)),
+         fill = precip_colors, border = NA, ncol = 5, box.col = NA,
+         cex = 0.8, x.intersp = 0.5, bg = "lightgrey", inset = -0.3, xpd = TRUE)
   
   dev.off()
   

--- a/viz.yaml
+++ b/viz.yaml
@@ -164,13 +164,24 @@ fetch:
     north: 43.809561
   -
     id: yahara_precip_avg
-    comment: use transposed yahara as stencil (need dates)
+    comment: use transposed yahara as stencil 
     location: cache/yahara_precip_avg.rds
     reader: rds
     fetcher: precip_data
     scripts: scripts/fetch/fetch.precip_data.R
     depends:
       geom_sp: "yahara_geom_transposed"
+      date_range: "storm_dates"
+    algorithm: "unweighted summary"
+  -
+    id: yahara_precip_orig_avg
+    comment: use original yahara as stencil 
+    location: cache/yahara_precip_orig_avg.rds
+    reader: rds
+    fetcher: precip_data
+    scripts: scripts/fetch/fetch.precip_data.R
+    depends:
+      geom_sp: "yahara_geom"
       date_range: "storm_dates"
     algorithm: "unweighted summary"
 #  -
@@ -205,6 +216,15 @@ process:
     scripts: scripts/process/process.precip_cumulative.R
     depends: 
       precip_data: "yahara_precip_avg"
+  -
+    id: yahara_precip_orig_avg_cumulative
+    comment: get cumulative avg precip from original yahara
+    location: cache/yahara_precip_orig_avg_cumulative.rds
+    reader: rds
+    processor: precip_cumulative
+    scripts: scripts/process/process.precip_cumulative.R
+    depends: 
+      precip_data: "yahara_precip_orig_avg"
   -
     id: yahara_precip_avg_timestep
     comment: filter to get just one precip value of the averaged precip data
@@ -295,6 +315,7 @@ visualize:
       precip_colors: "precip_colors"
       precip_breaks: "precip_breaks"
       precip_data: "yahara_precip_avg_cumulative"
+      precip_orig_data: "yahara_precip_orig_avg_cumulative"
       geom_sp: "yahara_geom_transposed"
       geom_sp_orig: "yahara_geom"
     title: Storm transposition

--- a/viz.yaml
+++ b/viz.yaml
@@ -94,7 +94,8 @@ parameter:
   -
     id: example_dateTime
     comment: use one timestep to illustrate geoknife processing
-    date: "2008-06-12 22:00:00 UTC"
+    date: "2008-06-12 22:00:00"
+    tz: "UTC"
   -
     id: precip_bins
     comment: number of bins for precip scale

--- a/viz.yaml
+++ b/viz.yaml
@@ -134,9 +134,10 @@ fetch:
     reader: rds
     fetcher: geom_shp
     scripts: scripts/fetch/fetch.geom_shp.R
-    depends: 
-      crs: "geoknife_crs"
+    depends:
+      transform_crs: "geoknife_crs"
     filepath: "data/yahara.shp"
+    shp_crs: "+init=epsg:3857"
   - 
     id: yahara_geom_transposed
     comment: moves yahara north (more process than fetch, but precip fetch depends on this)

--- a/viz.yaml
+++ b/viz.yaml
@@ -148,7 +148,7 @@ fetch:
     scripts: scripts/fetch/fetch.geom_transpose.R
     depends: 
       geom_sp: "yahara_geom"
-    vertical_trans_va: 0.15
+    vertical_trans_va: 0.2
   -
     id: context_geom
     comment: create spatial object of area around yahara (maybe just make bbox)	

--- a/viz.yaml
+++ b/viz.yaml
@@ -276,6 +276,8 @@ visualize:
     visualizer: map_precip
     scripts: scripts/visualize/visualize.map_precip.R
     depends:
+      precip_colors: "precip_colors"
+      precip_breaks: "precip_breaks"
       precip_data: "yahara_precip_avg_timestep"
       geom_sp: "yahara_geom_transposed"
     title: Processed GDP results for one timestep
@@ -288,6 +290,8 @@ visualize:
     visualizer: map_precip
     scripts: scripts/visualize/visualize.map_precip.R
     depends:
+      precip_colors: "precip_colors"
+      precip_breaks: "precip_breaks"
       precip_data: "yahara_precip_avg_cumulative"
       geom_sp: "yahara_geom_transposed"
       geom_sp_orig: "yahara_geom"


### PR DESCRIPTION
Make the maps showing the "melted" precip values look nicer w/ ggmap and a map background for context. Add in a fetch step to determine the cumulative average preicp for the original Yahara to include on the final storm transpose figure.

Thinking of separating the "melt" figure code into a different function so that it doesn't have a background. These will need a key added.