### PR TITLE
some add'l library bits to get dev to build

### DIFF
--- a/scripts/visualize/visualize.raster_map_precip.R
+++ b/scripts/visualize/visualize.raster_map_precip.R
@@ -1,5 +1,7 @@
 visualize.raster_map_precip <- function(viz = as.viz('yahara_precip_clip')){
   
+  library(ggplot2) # need to actually load this or rasterVis::gplot throws an error
+  
   deps <- readDepends(viz)
   precip_data <- deps[['raster_data']]
   

--- a/viz.yaml
+++ b/viz.yaml
@@ -36,6 +36,9 @@ info:
     geoknife:
       repo: CRAN
       version: 1.5.5
+    ggplot2:
+      repo: CRAN
+      version: 2.2.1
     maps:
       repo: CRAN
       version: 3.2.0

--- a/viz.yaml
+++ b/viz.yaml
@@ -48,6 +48,9 @@ info:
     raster:
       repo: CRAN
       version: 2.5-8
+    rasterVis:
+      repo: CRAN
+      version: 0.41
     RColorBrewer:
       repo: CRAN
       version: 1.1-2


### PR DESCRIPTION
Needed to specify that `ncdf4` and `ggplot2` are required libraries. Also need to load `ggplot2` inside `visualize.raster_map_precip` because `rasterVis::gplot` needs it.