### PR TITLE
unweighted summary --> summary

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -176,7 +176,7 @@ fetch:
     depends:
       geom_sp: "yahara_geom_transposed"
       date_range: "storm_dates"
-    algorithm: "unweighted summary"
+    algorithm: "summary"
   -
     id: yahara_precip_orig_avg
     comment: use original yahara as stencil 
@@ -187,7 +187,7 @@ fetch:
     depends:
       geom_sp: "yahara_geom"
       date_range: "storm_dates"
-    algorithm: "unweighted summary"
+    algorithm: "summary"
   -
     id: yahara_precip
     comment: use transposed yahara, use subset algorithm


### PR DESCRIPTION
Forgot to do this awhile ago I guess (or it was wiped our in a PR along the way). Unweighted is not what we want to use, plus causes an error when used in later versions of `geoknife` because of the progress bar (see https://github.com/USGS-R/geoknife/issues/366)